### PR TITLE
chore: update GitHub Actions workflows

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,305 @@
+---
+editor: 
+  markdown: 
+    wrap: 72
+---
+
+# Copilot Instructions for shigella
+
+## Repository Overview
+
+**shigella** is an R package for multivariate Bayesian hierarchical
+modeling of antibody response trajectories following confirmed Shigella
+infection. Chapter 2 extends the univariate Chapter 1 approach (handled
+upstream in the `serodynamics` package) to a Kronecker-structured
+covariance model ($\Sigma_B \otimes \Sigma_P$) implemented in Stan.
+
+-   **Type**: R package (statistical modeling)
+-   **Language**: R (\>= 4.1.0), Stan (cmdstanr backend)
+-   **Key Dependencies**: cmdstanr (\>= 0.9.0), serodynamics, posterior,
+    cli, dplyr, MASS, tibble
+-   **Lifecycle**: Experimental — Chapter 2 simulation is the active
+    branch (`chapter2-stan-simulation`)
+-   **Repository owner**: UCD-SERG (Aiemjoy / Morrison labs)
+
+## Lab-Wide Guidance
+
+Follow the [UCD-SeRG Lab Manual](https://ucd-serg.github.io/lab-manual/)
+for culture, reproducibility, GitHub workflows, coding practices, and AI
+tools usage. If the web version is inaccessible, refer to the [source
+files on GitHub](https://github.com/UCD-SERG/lab-manual).
+
+## Repository Structure
+
+This package follows strict standard R package layout. **Do not create
+subdirectories under `R/`, and do not place `R/`, `inst/`, or
+`vignettes/` folders inside any other directory** (e.g., a former
+`chapter2/R/` subfolder was a structural error and was removed; do not
+recreate that pattern).
+
+### Layout
+
+-   **`R/`**: All exported and internal R functions. One function per
+    file. File name must match function name (dotted internal helpers
+    like `.helper_fn()` go in `R/helper_fn.R` — drop the leading dot in
+    the filename only).
+-   **`inst/stan/`**: Stan model files (`model_1.stan`, `model_2.stan`).
+-   **`inst/examples/`**: One example script per exported function,
+    named `<function_name>-examples.R`.
+-   **`tests/testthat/`**: Unit tests, named `test-<function_name>.R`.
+-   **`vignettes/`**: Quarto vignettes (`.qmd`). Chapter 2
+    manuscript-style documentation goes here.
+-   **`scripts/`**: Shiva HPC orchestration scripts (Phase 0/1
+    diagnostic runs). Listed in `.Rbuildignore` — **not** part of the
+    package build.
+-   **`slurm/`**: SLURM sbatch files for Shiva. Also in `.Rbuildignore`.
+-   **`man/`**: Auto-generated documentation from roxygen2 — **do not
+    edit directly**.
+
+### Configuration Files
+
+-   **`DESCRIPTION`**: Package metadata. Keep `Imports` minimal
+    (currently cli, dplyr, MASS, tibble). Optional functionality belongs
+    in `Suggests`.
+-   **`NAMESPACE`**: Auto-generated — **do not edit**.
+-   **`.lintr`** and **`.lintr.R`**: Custom lintr configuration.
+-   **`.Rbuildignore`**: Must exclude `^scripts$`, `^slurm$`, and
+    `^chapter2$` (last for historical safety).
+
+## Review Priorities — What Copilot Should Flag
+
+### 1. R Package Structure
+
+-   All R functions live directly in `R/`. **No subdirectories**.
+-   Every exported function has:
+    -   `@title`, `@description`, `@param` for every argument,
+        `@return`, `@export`, and either `@examples` inline or
+        `@example inst/examples/<fn>-examples.R`.
+-   One function per file. File name matches function name. Internal
+    helpers are dotted (`.helper_fn()`) and live in `R/helper_fn.R`.
+-   Stan model files belong in `inst/stan/`, never in a nested folder.
+
+### 2. Examples That Actually Run
+
+-   Every exported function has a matching example file in
+    `inst/examples/<function_name>-examples.R`.
+-   Examples must NOT depend on confidential Shigella data files. Use
+    `sim_correlated_case_data()` to generate synthetic data instead.
+-   For Stan-fitting examples, use minimal settings (n = 5 subjects, 100
+    warmup + 100 sampling, 1 chain) so the example completes within \~5
+    minutes on CI. Wrap heavy fits in
+    `if (interactive() && requireNamespace("cmdstanr", quietly = TRUE))`.
+
+### 3. Unit Tests
+
+-   Every function in `R/` should have a test in
+    `tests/testthat/test-<function_name>.R`.
+-   For Stan-fitting tests, use minimal MCMC settings and consider
+    `testthat::skip_on_ci()` if the test exceeds \~5 minutes.
+-   Tests for `sim_correlated_case_data()` must verify the generated
+    data has the intended structure: correct dimensions, correct
+    ground-truth correlation sign, the `truth` attribute is present.
+
+### 4. Real-Data Handling
+
+-   Real Shigella data files (anything matching `dL_clean_*.rda`,
+    `data/*.rda` containing patient data, or `*.xlsx` with patient
+    records) MUST be in `.gitignore` and MUST NOT be committed.
+-   Flag any PR that adds files with `clean_`, `dL_`, or
+    patient-identifying content.
+
+### 5. Stan Model Files
+
+-   Stan files (`.stan`) belong in `inst/stan/`.
+-   Compiled Stan binaries (no extension, or `.exe`/`.hpp`) belong in
+    `.gitignore`.
+-   When a Stan model file is modified, verify:
+    -   Likelihood computed in log space (no `exp` followed by `log`).
+    -   Priors are weakly informative (sigma typically ≤ 5 on log-scale
+        parameters).
+    -   LKJ priors use `lkj_corr_cholesky`, not `lkj_corr` directly.
+-   Both the full Kronecker model (`model_2.stan`) and any future
+    block-covariance simplification (`model_2_block.stan`) should be
+    preserved. The convergence proposal identifies all four
+    cross-biomarker / cross-parameter covariance structures as
+    scientifically relevant; block simplification is an operational
+    trade-off, not a project-scope redefinition.
+
+### 6. Shiva HPC Scripts
+
+-   `scripts/` and `slurm/` are Shiva-only directories. They are not
+    built into the package and not expected to run in GitHub Actions. Do
+    NOT flag them for missing tests.
+-   However: the R functions they call (e.g., `run_phase0_diagnostic()`,
+    `run_phase1_diagnostic()`) live in `R/` and DO need to pass GitHub
+    Actions tests.
+-   Scripts must NOT contain function definitions or `source()` calls.
+    They contain only `library(shigella)`, parameter setup, and function
+    invocations. Flag any function definition or `source()` inside
+    `scripts/`.
+-   Phase 0 scripts are designed to run under `salloc` (interactive
+    SLURM allocation), NOT on the login node directly.
+
+### 7. Vignettes and Documentation
+
+-   Vignettes are Quarto `.qmd` files rendered with the `quarto`
+    package.
+-   Chapter 2 manuscript-style documentation belongs in a single
+    `vignettes/chapter2.qmd` with the standard 4-section structure
+    (Introduction / Methods / Results / Discussion), all math in one
+    file. Do not fragment into separate methods/demo files.
+
+## Style Preferences
+
+-   **Follow the tidyverse style guide**: https://style.tidyverse.org
+-   **Native pipe**: `|>` not `%>%`
+-   **Naming**: snake_case for functions, arguments, and most objects.
+    Uppercase acronyms allowed (e.g., `Omega_B`, `tau_P`). Constants use
+    UPPER_SNAKE_CASE.
+-   **Maximum line length**: 120 characters (per `.lintr`).
+-   **No `library()` in package code**: Use `::` or declare in
+    `DESCRIPTION` Imports.
+-   **`source()` is banned in the package**. Use `library(shigella)` for
+    end-user contexts (vignettes, examples, scripts) or
+    `devtools::load_all()` for developer workflows.
+-   **No `<<-`** (global assignment).
+-   **User-facing messages** use `cli::cli_inform()`, `cli::cli_warn()`,
+    `cli::cli_abort()` — not `message()`, `warning()`, `stop()`. See
+    `.lintr.R` for the enforced list.
+-   **No developer names in user-facing messages.** Strip any reference
+    to specific people ("Kwan Ho", "Ezra", etc.) from `cli::cli_*()`,
+    `cat()`, `message()` output.
+-   **Decompose long functions and long loops**: any R function \> \~40
+    lines or any loop body \> \~5 lines should be split into named
+    helpers (one function per file).
+
+## Build and Development Workflow
+
+### Setup
+
+``` r
+# Install development dependencies
+install.packages(c("devtools", "remotes"))
+remotes::install_github("UCD-SERG/serodynamics", upgrade = "never",
+                        dependencies = NA)
+install.packages("cmdstanr",
+                 repos = c("https://stan-dev.r-universe.dev",
+                           "https://cloud.r-project.org"))
+cmdstanr::install_cmdstan()
+
+# Install the package itself
+devtools::install(".", upgrade = "never")
+```
+
+For minimal install (skipping `Suggests`), use base R:
+
+``` bash
+cd ~/shigella
+R CMD INSTALL .
+```
+
+### Documentation Generation
+
+**Always regenerate documentation after modifying roxygen2 comments.**
+
+``` r
+devtools::document()
+```
+
+`man/` and `NAMESPACE` are auto-generated. Do not edit directly.
+
+### Package Checking
+
+``` r
+devtools::check()
+```
+
+Allow \~5 minutes. Acceptable post-cleanup state: 0 errors, 0 warnings,
+≤1 NOTE (the `serodynamics:::calc_fit_mod` triple-colon use is a known
+tolerated exception, marked with `# nolint: namespace_linter`).
+
+### Testing
+
+``` r
+devtools::test()
+```
+
+Tests live in `tests/testthat/` and use testthat 3.0+ with edition 3
+config (see `DESCRIPTION`).
+
+### Linting
+
+``` r
+lintr::lint_package()
+```
+
+**Lint must be clean on every commit.** Treat lint failures with the
+same urgency as test failures. See `.lintr.R` for the full custom
+config. Custom rules include:
+
+-   `cli::cli_*()` enforced over `message()`/`warning()`/`stop()`.
+-   Native pipe `|>` enforced over `%>%`.
+-   snake_case with uppercase acronyms allowed.
+-   `source()` flagged.
+
+If a lint must be suppressed, use `# nolint: <linter_name>` on the
+specific line with a justifying comment, and mention it in your PR
+summary.
+
+### Spelling
+
+``` r
+spelling::spell_check_package()
+```
+
+Custom words live in `inst/WORDLIST`.
+
+## Continuous Integration
+
+The following workflows run on every PR. **All must pass** for merge:
+
+1.  **R-CMD-check.yaml** — Runs `R CMD check` on multiple platforms.
+2.  **lint-changed-files.yaml** — Lints PR-changed files with the custom
+    `.lintr.R` config. Fails on any lint.
+3.  **check-spelling.yaml** — Spell check.
+4.  **R-check-docs.yml** — Verifies `roxygen2::roxygenise()` output
+    matches committed `man/` and `NAMESPACE`.
+5.  **pkgdown.yaml** — Builds the pkgdown site.
+
+## Things Not to Flag
+
+-   `scripts/` and `slurm/` directories at the repo root — intentional
+    Shiva-only directories listed in `.Rbuildignore`.
+-   The `serodynamics:::calc_fit_mod` triple-colon call in
+    `R/run_mod_stan.R` — known tolerated until upstream exports it.
+-   Stan and JAGS files — not lintable as R code.
+-   Tests appropriately skipped on CI with explanations.
+
+## Contact
+
+-   **Repository owner**: UCD-SERG (Aiemjoy / Morrison labs)
+-   **Primary maintainer (Chapter 2)**: Kwan Ho Lee
+    (ksjlee\@ucdavis.edu)
+-   **Co-advisors**: Kristen Aiemjoy, Douglas Ezra Morrison
+
+## Trust These Instructions
+
+When making changes:
+
+1.  **ALWAYS** keep all function definitions inside `R/`, one per file.
+2.  **ALWAYS** preserve numerical/statistical logic (priors, parameter
+    names, simulation semantics) unless there is a clear bug.
+3.  **ALWAYS** run `lintr::lint_package()` and fix every issue in the
+    same commit. Never push a commit that introduces or leaves a lint.
+4.  **ALWAYS** run `devtools::document()` after modifying roxygen2.
+5.  **ALWAYS** run `devtools::check()` and `devtools::test()` locally
+    before requesting review.
+6.  **NEVER** add a `source()` call or define a function inside
+    `scripts/` or `vignettes/`.
+7.  **NEVER** commit real Shigella data or files matching
+    `dL_clean_*.rda` or patient data spreadsheets.
+8.  **NEVER** modify `inst/stan/*.stan` files for stylistic reasons —
+    only for clearly documented bug fixes.
+
+Only search for additional information if these instructions are
+incomplete or incorrect for your specific task.

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           extra-packages: any::rcmdcheck, any::cmdstanr
           needs: check
-          
       - name: Cache CmdStan installation
         id: cache-cmdstan
         uses: actions/cache@v4
@@ -67,8 +66,8 @@ jobs:
         shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
-        env:                                      
-          RUN_STAN_TESTS: "true"                
+        env:
+          RUN_STAN_TESTS: "true"
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,6 +21,8 @@ jobs:
         config:
           - {os: ubuntu-latest, r: 'release'}
           - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release'}
+          - {os: macos-latest, r: 'release'}
+          - {os: windows-latest, r: 'release'}
 
     env:
       GITHUB_PAT: ${{ github.token }}
@@ -41,8 +43,32 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           needs: check
+          
+      - name: Cache CmdStan installation
+        id: cache-cmdstan
+        uses: actions/cache@v4
+        with:
+          path: ~/.cmdstan
+          key: cmdstan-${{ runner.os }}-2.36.0
+          restore-keys: |
+            cmdstan-${{ runner.os }}-
+
+      - name: Install CmdStan
+        if: steps.cache-cmdstan.outputs.cache-hit != 'true'
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cmdstanr::install_cmdstan(
+            cores     = 2,
+            overwrite = FALSE,
+            version   = "2.36.0"
+          )
+        shell: Rscript {0}
 
       - uses: r-lib/actions/check-r-package@v2
+        env:                                      
+          RUN_STAN_TESTS: "true"                
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, any::cmdstanr
           needs: check
           
       - name: Cache CmdStan installation

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::cmdstanr
+          extra-packages: any::rcmdcheck, stan-dev/cmdstanr
           needs: check
       - name: Cache CmdStan installation
         id: cache-cmdstan

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -100,7 +100,6 @@ jobs:
             any::testthat
             any::posterior
             any::cmdstanr
-            stan-dev/cmdstanr
             d-morrison/altdoc@recursive-qmd-search
           needs: check
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -99,7 +99,7 @@ jobs:
             any::rmarkdown
             any::testthat
             any::posterior
-            any::cmdstanr
+            stan-dev/cmdstanr
             d-morrison/altdoc@recursive-qmd-search
           needs: check
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,189 @@
+# GitHub Copilot Setup Steps for the shigella repository
+#
+# This workflow configures the GitHub Copilot coding agent's environment
+# by preinstalling R, Stan/cmdstanr, JAGS, Quarto, and required system
+# dependencies needed to validate the Chapter 1 (JAGS) and Chapter 2
+# (Stan) antibody-kinetics simulation code.
+#
+# Reference: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/
+#            coding-agent/customize-the-agent-environment
+#
+# This setup is based on the serodynamics and lab-manual versions but
+# additionally installs JAGS (for Chapter 1 model.jags) and cmdstan (for
+# Chapter 2 model_2.stan).
+
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job must be called `copilot-setup-steps` or it will not be
+  # picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: read
+
+    timeout-minutes: 55
+
+    steps:
+      - name: Check if setup should be skipped
+        id: check_label
+        shell: bash
+        run: |
+          if [[ '${{ github.event_name }}' != 'pull_request' ]]; then
+            echo "Not a pull request, running full setup"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          elif [[ "${{ contains(github.event.pull_request.labels.*.name, 'skip-cp-setup') }}" == 'true' ]]; then
+            echo "Skip label present, skipping most setup steps"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "Skip label not present, running full setup"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # System dependencies, including JAGS for Chapter 1 model.jags
+      - name: Install system dependencies
+        if: steps.check_label.outputs.skip != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            jags \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libxml2-dev \
+            libfontconfig1-dev \
+            libharfbuzz-dev \
+            libfribidi-dev \
+            libfreetype6-dev \
+            libpng-dev \
+            libtiff5-dev \
+            libjpeg-dev
+
+      - name: Set up Pandoc
+        if: steps.check_label.outputs.skip != 'true'
+        uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Set up R
+        if: steps.check_label.outputs.skip != 'true'
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      # Install R package dependencies declared in DESCRIPTION
+      - name: Install R dependencies
+        if: steps.check_label.outputs.skip != 'true'
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::devtools
+            any::rcmdcheck
+            any::lintr
+            any::spelling
+            any::rmarkdown
+            any::testthat
+            any::posterior
+            any::cmdstanr
+            stan-dev/cmdstanr
+            d-morrison/altdoc@recursive-qmd-search
+          needs: check
+
+      # Install cmdstan (required for any Stan models)
+      - name: Install cmdstan
+        if: steps.check_label.outputs.skip != 'true'
+        run: |
+          Rscript -e '
+            if (!requireNamespace("cmdstanr", quietly = TRUE)) {
+              install.packages("cmdstanr",
+                repos = c("https://stan-dev.r-universe.dev",
+                         getOption("repos")))
+            }
+            cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+            cmdstanr::install_cmdstan(cores = 2, overwrite = FALSE)
+            cat("\ncmdstan version: ",
+                as.character(cmdstanr::cmdstan_version()), "\n")
+          '
+
+      - name: Set up Quarto
+        if: steps.check_label.outputs.skip != 'true'
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Verify everything is installed
+      - name: Verify development environment
+        if: steps.check_label.outputs.skip != 'true'
+        run: |
+          echo "=== R Status ==="
+          R --version
+          echo ""
+
+          echo "=== JAGS Status ==="
+          jags -v || echo "JAGS check exit code: $?"
+          echo ""
+
+          echo "=== cmdstan Status ==="
+          Rscript -e 'cat("cmdstan version:", as.character(cmdstanr::cmdstan_version()), "\n")'
+          echo ""
+
+          echo "=== Quarto Status ==="
+          quarto --version
+          quarto check
+          echo ""
+
+          echo "=== installed R packages (key ones) ==="
+          Rscript -e '
+            pkgs <- c("rjags", "runjags", "cmdstanr", "posterior",
+                     "devtools", "testthat", "rmarkdown")
+            for (p in pkgs) {
+              installed <- requireNamespace(p, quietly = TRUE)
+              cat(sprintf("  %-12s: %s\n", p,
+                  if (installed) "OK" else "MISSING"))
+            }
+          '
+
+      # Diagnostic block — does not fail the workflow
+      - name: Run package diagnostics
+        if: steps.check_label.outputs.skip != 'true'
+        continue-on-error: true
+        run: |
+          echo "=== Running Package Diagnostics ==="
+          echo "Diagnostic failures here do not fail the workflow;"
+          echo "they are reported for Copilot to read."
+          echo ""
+
+          echo "--- Linting with lintr::lint_package() ---"
+          Rscript -e "devtools::load_all(); lintr::lint_package()" || true
+          echo ""
+
+          echo "--- Generating documentation with devtools::document() ---"
+          Rscript -e "devtools::document()" || true
+          echo ""
+
+          echo "--- Running tests with devtools::test() ---"
+          Rscript -e "devtools::test()" || true
+          echo ""
+
+          echo "--- Running R CMD check ---"
+          Rscript -e "devtools::check(error_on = 'never')" || true
+          echo ""
+
+          echo "=== Package Diagnostics Complete ==="

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -114,7 +114,7 @@ jobs:
                          getOption("repos")))
             }
             cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-            cmdstanr::install_cmdstan(cores = 2, overwrite = FALSE)
+            cmdstanr::install_cmdstan(cores = 2, overwrite = FALSE, version = "2.36.0")
             cat("\ncmdstan version: ",
                 as.character(cmdstanr::cmdstan_version()), "\n")
           '

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -10,8 +10,8 @@ permissions: read-all
 jobs:
   lint-changed-files:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    
+    
     steps:
       - uses: actions/checkout@v4
 
@@ -35,11 +35,18 @@ jobs:
 
       - name: Extract and lint files changed by this PR
         run: |
-          files <- gh::gh("GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
+          Sys.unsetenv("GITHUB_PAT")
+
+          files <- gh::gh(
+            "GET https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files",
+            .token = Sys.getenv("GITHUB_TOKEN")
+          )
+          
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)
           exclusions_list <- as.list(setdiff(all_files, changed_files))
           lintr::lint_package(exclusions = exclusions_list)
         shell: Rscript {0}
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           LINTR_ERROR_ON_LINT: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2, any::cmdstanr
+          extra-packages: any::covr, any::xml2, stan-dev/cmdstanr
           needs: coverage
 
       - name: Cache CmdStan installation

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
+          extra-packages: any::covr, any::xml2, any::cmdstanr
           needs: coverage
 
       # ADD THIS: cache CmdStan

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -27,7 +27,6 @@ jobs:
           extra-packages: any::covr, any::xml2, any::cmdstanr
           needs: coverage
 
-      # ADD THIS: cache CmdStan
       - name: Cache CmdStan installation
         id: cache-cmdstan
         uses: actions/cache@v4
@@ -37,7 +36,6 @@ jobs:
           restore-keys: |
             cmdstan-${{ runner.os }}-
 
-      # ADD THIS: install CmdStan if cache is missing
       - name: Install CmdStan
         if: steps.cache-cmdstan.outputs.cache-hit != 'true'
         env:
@@ -92,4 +90,5 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          
           

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -27,7 +27,34 @@ jobs:
           extra-packages: any::covr, any::xml2
           needs: coverage
 
+      # ADD THIS: cache CmdStan
+      - name: Cache CmdStan installation
+        id: cache-cmdstan
+        uses: actions/cache@v4
+        with:
+          path: ~/.cmdstan
+          key: cmdstan-${{ runner.os }}-2.36.0
+          restore-keys: |
+            cmdstan-${{ runner.os }}-
+
+      # ADD THIS: install CmdStan if cache is missing
+      - name: Install CmdStan
+        if: steps.cache-cmdstan.outputs.cache-hit != 'true'
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cmdstanr::check_cmdstan_toolchain()
+          cmdstanr::install_cmdstan(
+            cores     = 2,
+            overwrite = FALSE,
+            version   = "2.36.0"
+          )
+        shell: Rscript {0}
+
       - name: Test coverage
+        env:
+          RUN_STAN_TESTS: "true"
         run: |
           cov <- covr::package_coverage(
             quiet = FALSE,
@@ -65,3 +92,4 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: shigella
 Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: c(
     person("Kwan Ho", "Lee", , "ksjlee@ucdavis.edu", role = c("aut", "cre")),
     person("Douglas Ezra", "Morrison", , "demorrison@ucdavis.edu", role = c("aut"),
@@ -9,7 +9,6 @@ Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 Imports: 
     cli,
     dplyr,
@@ -61,3 +60,4 @@ LazyData: true
 Config/testthat/edition: 3
 Config/Needs/website: quarto
 Language: en-US
+Config/roxygen2/version: 8.0.0

--- a/man/shigella-package.Rd
+++ b/man/shigella-package.Rd
@@ -20,6 +20,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Kwan Ho Lee \email{ksjlee@ucdavis.edu}
   \item Douglas Ezra Morrison \email{demorrison@ucdavis.edu} (\href{https://orcid.org/0000-0002-7195-830X}{ORCID})
 }
 


### PR DESCRIPTION
## Summary

This PR separates the GitHub Actions workflow changes from PR #13.

Merging this first will reduce the diff in PR #13 so reviewers can focus on the new substantive Chapter 2 Stan simulation changes.

## Changes

- Updates `.github/workflows/R-CMD-check.yaml`
  - Adds macOS/Windows matrix
  - Adds CmdStan installation step
  - Sets `RUN_STAN_TESTS=true`

- Adds `.github/workflows/copilot-setup-steps.yml`
  - Sets up the Copilot agent environment with cmdstanr, JAGS, and Quarto

- Updates `.github/workflows/lint-changed-files.yaml`
  - Adds `GITHUB_TOKEN`
  - Switches to changed-files linting

- Updates `.github/workflows/test-coverage.yaml`
  - Adds CmdStan installation step
  - Sets `RUN_STAN_TESTS=true`

- Adds `.github/copilot-instructions.md`
  - Adds repository-specific Copilot coding instructions

## Related PR

Split out from PR #13.