### PR TITLE
claude.yml: enable show_full_output for diagnosis

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Temporarily on to surface the real SDK error message.
+          # Revert once we've diagnosed the auth/init failure on PR comments.
+          show_full_output: true
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary
- The `@claude` GitHub Action keeps failing on PR comments with a generic `Claude Code process exited with code 1`; the real error from the spawned `claude` CLI child process is hidden because the action defaults to `show_full_output: false`.
- This flips it on so the next `@claude` invocation surfaces the actual error message in the action log.

## Context
- Reproduced on PR #13 across multiple runs (e.g. [run 26310118052](https://github.com/UCD-SERG/shigella/actions/runs/26310118052)).
- Initially looked like a missing `ANTHROPIC_API_KEY` — that was fixed via `/install-github-app` (OAuth token now flows through; OIDC/app-token exchange succeeds).
- Subsequent failure looked like the `fetchGitHubData → git hash-object` errors, but those are caught (`Successfully fetched PR #13 data` follows) and the action then performs its own internal PR-branch checkout (`Successfully checked out PR branch for PR #13`).
- The real crash is downstream, inside Claude Code `2.1.148` spawned via the SDK. The stack trace lands in minified Anthropic SDK auth-init code (`apiKey` / `authToken` / `credentials` resolution), but the actual error string is suppressed.

## After we have the diagnosis
Revert this PR (or just remove the `show_full_output: true` line).

## Test plan
- [ ] Merge to `main`.
- [ ] Post a fresh `@claude ping` (or any `@claude ...`) comment on an open PR.
- [ ] Inspect the resulting `Run Claude Code` job log for the real error message under the SDK execution error.