### PR TITLE
claude.yml: revert debug flag + pre-write credentials workaround for action#1281

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Temporarily on to surface the real SDK error message.
-          # Revert once we've diagnosed the auth/init failure on PR comments.
-          show_full_output: true
-
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Workaround for anthropics/claude-code-action#1281: the OAuth token
+      # passed via `claude_code_oauth_token:` intermittently doesn't reach the
+      # spawned Claude Code subprocess, which then crashes at SDK init with
+      # `apiKey`/`authToken` both null. Pre-writing the credentials file (same
+      # path/format `claude setup-token` would produce locally) is the
+      # documented bypass — the CLI reads it directly.
+      - name: Pre-write Claude credentials (workaround for action#1281)
+        run: |
+          mkdir -p "$HOME/.claude"
+          cat > "$HOME/.claude/.credentials.json" <<'EOF'
+          {"claudeAiOauth": {"accessToken": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}", "subscriptionType": "max"}}
+          EOF
+          chmod 600 "$HOME/.claude/.credentials.json"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
Two related changes to `claude.yml`:

1. **Revert `show_full_output: true`** (from #17). The flag was only there to diagnose the SDK crash; it didn't surface a more actionable error (the CLI's stderr isn't piped through anyway), so leaving it on is just noise + a mild data-leak risk.

2. **Pre-write `~/.claude/.credentials.json`** before the action runs. This is a documented workaround for [anthropics/claude-code-action#1281](https://github.com/anthropics/claude-code-action/issues/1281): the OAuth token passed via `claude_code_oauth_token:` intermittently doesn't propagate to the spawned Claude Code subprocess, which then crashes at SDK init with both `apiKey` and `authToken` null. We've hit this multiple times on PR #13 with one transient success in between ([run 26345098509](https://github.com/UCD-SERG/shigella/actions/runs/26345098509) is the latest failure). Pre-writing the credentials file — same path/format `claude setup-token` produces locally — lets the CLI read the token directly instead of going through the broken propagation path. The token is still also passed via `with:` so the action's OIDC/app-token exchange keeps working.

Pattern lifted from [stefanroman22/cms-platform#42](https://github.com/stefanroman22/cms-platform/pull/42), which hit the same upstream bug under cron and ultimately bypassed the action entirely. That bypass works for `workflow_dispatch`/cron flows; our `@claude` tag-mode setup gets too much for free from the action (sticky comment, MCP tools, prompt parsing) to justify a full bypass yet — so we try the lighter-touch credentials-file workaround first.

## Test plan
- [ ] Merge.
- [ ] Post `@claude ping` (or any `@claude …`) on an open PR.
- [ ] If the run succeeds, ping a couple more times to confirm the intermittent failure has stopped recurring.
- [ ] If it still fails, escalate to the full direct-CLI bypass.