### PR TITLE
claude.yml: drop credentials pre-write step (workaround didn't work)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,20 +30,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Workaround for anthropics/claude-code-action#1281: the OAuth token
-      # passed via `claude_code_oauth_token:` intermittently doesn't reach the
-      # spawned Claude Code subprocess, which then crashes at SDK init with
-      # `apiKey`/`authToken` both null. Pre-writing the credentials file (same
-      # path/format `claude setup-token` would produce locally) is the
-      # documented bypass — the CLI reads it directly.
-      - name: Pre-write Claude credentials (workaround for action#1281)
-        run: |
-          mkdir -p "$HOME/.claude"
-          cat > "$HOME/.claude/.credentials.json" <<'EOF'
-          {"claudeAiOauth": {"accessToken": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}", "subscriptionType": "max"}}
-          EOF
-          chmod 600 "$HOME/.claude/.credentials.json"
-
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
The pre-write `~/.claude/.credentials.json` workaround added in #18 doesn't actually fix the intermittent OAuth-propagation failure. Verified on [run 26347004531](https://github.com/UCD-SERG/shigella/actions/runs/26347004531): the workflow step ran successfully (`✓ Pre-write Claude credentials`) and the action still crashed with the same SDK init error.

Looking at the log timeline:

```
Installing Claude Code v2.1.150...
Restoring .claude, .mcp.json, .claude.json, ... from origin/main (PR head is untrusted)
SDK execution error: ...
```

The action restores `~/.claude/` from `origin/main` as a security measure *after* our pre-write step — that restoration wipes the credentials file we wrote. Same dead-end stefanroman22 hit in [cms-platform#42](https://github.com/stefanroman22/cms-platform/pull/42) before they fully bypassed the action.

Removing the dead workaround. The upstream bug ([action#1281](https://github.com/anthropics/claude-code-action/issues/1281)) is unresolved; we're parking on it rather than rebuilding tag-mode around a direct `claude` CLI invocation right now.

## Test plan
- [ ] Merge.
- [ ] No behavior change expected for `@claude` — it'll keep failing intermittently the same way until the upstream bug is fixed.