### PR TITLE
claude.yml: pass GH_TOKEN to Run Claude step

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -225,6 +225,9 @@ jobs:
           # The CLI reads CLAUDE_CODE_OAUTH_TOKEN as a belt-and-suspenders
           # backup to the credentials file.
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Required so Claude can use the `Bash(gh ...)` tools in the
+          # allowlist (gh CLI errors out without auth even on read ops).
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
           # stdout → comment body. stderr → log AND a file so the


### PR DESCRIPTION
## Summary
The direct-CLI bypass grants Claude `Bash(gh pr view:*)`, `Bash(gh api:*)`, etc. as tools, but the `Run Claude` step's `env:` block only sets `CLAUDE_CODE_OAUTH_TOKEN` — not `GH_TOKEN`. The `gh` CLI errors out without auth even on read-only operations, so every `gh` call from Claude was failing.

Surfaced when the bot ran on PR #13 and self-diagnosed: it tried to fetch a referenced PR comment, hit `set the GH_TOKEN environment variable`, and posted [an unusually helpful explanation](https://github.com/UCD-SERG/shigella/pull/13#issuecomment-4529754809) including the exact fix.

## Test plan
- [ ] Merge.
- [ ] Post `@claude` on a PR with a question that requires reading another comment or run log (e.g., "summarize the failing CI check"). Confirm Claude can use `gh` tools without auth errors.