### PR TITLE
claude.yml: bump --max-turns from 20 to 100

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -232,8 +232,11 @@ jobs:
           set -o pipefail
           # stdout → comment body. stderr → log AND a file so the
           # "Update sticky comment" step can surface it on failure.
+          # --max-turns is a safety cap on tool-call iterations; 20 was too
+          # low for substantive review/fix on a 100-file PR (hit ceiling on
+          # PR #13). The 25-minute job timeout is the real backstop.
           claude --print \
-            --max-turns 20 \
+            --max-turns 100 \
             --allowed-tools 'Read,Glob,Grep,LS,Edit,Write,Bash(git add:*),Bash(git commit:*),Bash(git rm:*),Bash(git mv:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(npm:*),Bash(Rscript:*),Bash(R CMD:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr checks:*),Bash(gh issue view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh api:*)' \
             --disallowed-tools 'Bash(git push:*),WebFetch' \
             < /tmp/claude-prompt.txt \


### PR DESCRIPTION
## Summary
`@claude review and fix` on PR #13 hit `Error: Reached max turns (20)` ([comment](https://github.com/UCD-SERG/shigella/pull/13#issuecomment-4530033964)). 20 is too low for substantive review/fix on a 100-file PR — every Read and Grep counts as a turn, so the budget evaporates before Claude can finish reading the diff.

Bumping to 100. The 25-minute job timeout is the real safety net against runaway loops.

## Test plan
- [ ] Merge.
- [ ] Re-run `@claude review and fix` on a big PR; confirm it doesn't hit the 100-turn ceiling on a normal task.