### PR TITLE
claude.yml: don't discard Claude's staged-but-uncommitted edits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -256,17 +256,20 @@ jobs:
           PR_HEAD_SHA: ${{ steps.ctx.outputs.pr_head_sha }}
         run: |
           set -euo pipefail
-          # Only push if Claude actually committed something on top of the
-          # PR head SHA we checked out.
-          if [ "$(git rev-parse HEAD)" = "$PR_HEAD_SHA" ]; then
-            echo "No new commits from Claude."
-            exit 0
-          fi
-          # Also sweep any uncommitted edits into a final commit so we don't
-          # lose work if Claude forgot to commit.
+          # Sweep any uncommitted/staged edits into a commit FIRST. Claude
+          # sometimes runs `git add` without `git commit` and reports "files
+          # are staged"; without this sweep happening before the
+          # HEAD-unchanged check below, those edits would be silently
+          # discarded.
           if [ -n "$(git status --porcelain)" ]; then
             git add -A
             git commit -m "@claude: auto-commit residual uncommitted changes"
+          fi
+          # Now check whether HEAD has moved past the PR head SHA we
+          # checked out. If not, Claude made no committable changes.
+          if [ "$(git rev-parse HEAD)" = "$PR_HEAD_SHA" ]; then
+            echo "No new commits from Claude."
+            exit 0
           fi
           git push origin "HEAD:$PR_HEAD_REF"
 


### PR DESCRIPTION
## Summary
When `@claude` ran on PR #13 ([run 26373778702](https://github.com/UCD-SERG/shigella/actions/runs/26373778702)), Claude staged two file edits with `git add` but didn't `git commit` ([the comment it posted](https://github.com/UCD-SERG/shigella/pull/13#issuecomment-4530065757) literally says "Both files are staged. The workflow's Push Claude's commits to PR branch step will auto-commit them..."). The push step output `No new commits from Claude` and dropped the work on the floor.

## Bug
In the `Push Claude's commits to PR branch` step, the early-exit on `HEAD == PR_HEAD_SHA` ran BEFORE the "sweep uncommitted edits" branch:

```bash
# BEFORE
if [ "$(git rev-parse HEAD)" = "$PR_HEAD_SHA" ]; then
  echo "No new commits from Claude."
  exit 0   # ← staged edits silently lost here
fi
if [ -n "$(git status --porcelain)" ]; then
  git add -A
  git commit -m "..."
fi
git push ...
```

Staged-but-uncommitted edits don't move HEAD, so the early-exit fires and the sweep never gets a chance to commit them.

## Fix
Reorder: sweep first, then check HEAD.

```bash
# AFTER
if [ -n "$(git status --porcelain)" ]; then
  git add -A
  git commit -m "..."
fi
if [ "$(git rev-parse HEAD)" = "$PR_HEAD_SHA" ]; then
  echo "No new commits from Claude."
  exit 0
fi
git push ...
```

## Test plan
- [ ] Merge.
- [ ] Re-trigger `@claude` on PR #13 with a request that produces file edits. Confirm the staged edits land as a commit on the PR branch.