### PR TITLE
Add weekly check for upstream claude-code-action#1281 fix

### DIFF
--- a/.github/templates/claude-simple.yml
+++ b/.github/templates/claude-simple.yml
@@ -1,0 +1,52 @@
+# Simple "official action" version of claude.yml — what we want to revert
+# to once anthropics/claude-code-action#1281 is fixed upstream.
+#
+# .github/workflows/check-upstream-claude-fix.yml copies this file over
+# .github/workflows/claude.yml and opens a simplification PR when the
+# upstream issue closes as COMPLETED. Do not move or rename this file
+# without updating that workflow's `cp` source path.
+#
+# This file lives outside .github/workflows/ so GitHub Actions doesn't
+# try to run it as a workflow.
+
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/check-upstream-claude-fix.yml
+++ b/.github/workflows/check-upstream-claude-fix.yml
@@ -1,0 +1,141 @@
+# Weekly check: has anthropics/claude-code-action#1281 been fixed upstream?
+#
+# That issue is the OAuth-token propagation bug that forced us to bypass
+# the official action and roll our own direct-CLI workflow in
+# .github/workflows/claude.yml. Once it's resolved upstream, we want to
+# revert to the simple official-action invocation (the template at
+# .github/templates/claude-simple.yml).
+#
+# This workflow:
+#   1. Runs every Monday at 12:00 UTC (and on workflow_dispatch).
+#   2. Checks the state of issue #1281 via `gh issue view`.
+#   3. If state == CLOSED and stateReason == COMPLETED, copies the
+#      template over claude.yml on a fresh branch and opens a PR.
+#   4. Skips if the simplification PR already exists or the template
+#      already matches claude.yml.
+
+name: Check upstream claude-code-action fix
+
+on:
+  schedule:
+    - cron: '0 12 * * 1' # Mondays at 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history so the new branch can be created and pushed
+          # cleanly.
+          fetch-depth: 0
+
+      - name: Inspect upstream issue #1281
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          data=$(gh issue view 1281 \
+            --repo anthropics/claude-code-action \
+            --json state,stateReason,closedAt,url,title)
+          echo "$data" | jq .
+
+          state=$(echo "$data" | jq -r '.state')
+          reason=$(echo "$data" | jq -r '.stateReason // "null"')
+
+          # Only treat as "fixed" if CLOSED + COMPLETED. NOT_PLANNED and
+          # DUPLICATE don't mean a fix shipped; REOPENED would show as OPEN.
+          if [ "$state" = "CLOSED" ] && [ "$reason" = "COMPLETED" ]; then
+            echo "fixed=true" >> "$GITHUB_OUTPUT"
+            echo "Issue is CLOSED + COMPLETED — proceeding."
+          else
+            echo "fixed=false" >> "$GITHUB_OUTPUT"
+            echo "Issue state=$state reason=$reason — nothing to do."
+          fi
+
+      - name: Check whether claude.yml already matches the simple template
+        id: matches
+        if: steps.issue.outputs.fixed == 'true'
+        run: |
+          set -euo pipefail
+          if [ ! -f .github/templates/claude-simple.yml ]; then
+            echo "Template missing: .github/templates/claude-simple.yml" >&2
+            exit 1
+          fi
+          if cmp -s .github/templates/claude-simple.yml .github/workflows/claude.yml; then
+            echo "already_simple=true" >> "$GITHUB_OUTPUT"
+            echo "claude.yml already matches template — nothing to simplify."
+          else
+            echo "already_simple=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an existing simplification PR
+        id: existing
+        if: steps.issue.outputs.fixed == 'true' && steps.matches.outputs.already_simple == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          number=$(gh pr list --repo "$REPO" \
+            --head "simplify/claude-yml-after-upstream-fix" \
+            --state open --json number --jq '.[0].number // empty')
+          if [ -n "$number" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Existing PR #$number is open — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply template + open simplification PR
+        if: |
+          steps.issue.outputs.fixed == 'true' &&
+          steps.matches.outputs.already_simple == 'false' &&
+          steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b simplify/claude-yml-after-upstream-fix
+          cp .github/templates/claude-simple.yml .github/workflows/claude.yml
+          git add .github/workflows/claude.yml
+          git commit -m "claude.yml: revert bypass — upstream anthropics/claude-code-action#1281 fixed"
+          git push -u origin simplify/claude-yml-after-upstream-fix
+
+          gh pr create \
+            --base main \
+            --head simplify/claude-yml-after-upstream-fix \
+            --title "claude.yml: revert bypass — upstream #1281 fixed" \
+            --body "$(cat <<'EOF'
+          ## Summary
+
+          Upstream issue [anthropics/claude-code-action#1281](https://github.com/anthropics/claude-code-action/issues/1281) is now **CLOSED as COMPLETED**. That bug was the reason we rolled our own direct-CLI bypass in `claude.yml` (see #20 and follow-ups).
+
+          This PR reverts `claude.yml` back to the simple official-action invocation stored in `.github/templates/claude-simple.yml`.
+
+          Auto-generated by `.github/workflows/check-upstream-claude-fix.yml` running on a weekly cron.
+
+          ## Before merging
+
+          - [ ] Skim the upstream issue thread to confirm the fix actually shipped (vs. being closed by a stale-bot or as a side-effect of a re-architecture)
+          - [ ] Confirm the action's pinned version (`@v1`) resolves to a release that includes the fix
+          - [ ] Optional: post `@claude ping` on a test PR after merging to confirm tag-mode auth works
+
+          ## Test plan
+
+          - [ ] Merge
+          - [ ] Post `@claude ping` on an open PR; confirm the official action responds and the OAuth token doesn't crash at SDK init
+          - [ ] If anything regresses, `git revert` this commit — the bypass workflow is preserved in git history and the template stays in the repo for next time
+          EOF
+          )"


### PR DESCRIPTION
## Summary

When upstream [anthropics/claude-code-action#1281](https://github.com/anthropics/claude-code-action/issues/1281) is fixed, we want to revert our direct-CLI bypass in `claude.yml` (built in #20 and iterated through #21, #22, #23, #24) back to the simple official-action invocation. Manual noticing won't happen, so this PR automates the watch.

## What it adds

**`.github/templates/claude-simple.yml`** — static template = what `claude.yml` should look like after the upstream fix. Stored outside `.github/workflows/` so GHA doesn't try to run it as a workflow. Mirrors the pre-bypass `claude.yml` from before #20.

**`.github/workflows/check-upstream-claude-fix.yml`** — weekly check (Mondays 12:00 UTC, also `workflow_dispatch`). Steps:

1. `gh issue view 1281 --repo anthropics/claude-code-action --json state,stateReason,...`
2. If `state == CLOSED && stateReason == COMPLETED` → continue (a `NOT_PLANNED` or `DUPLICATE` closure doesn't mean a fix shipped)
3. `cmp` the template against current `claude.yml` — skip if they already match
4. Look for an existing open `simplify/claude-yml-after-upstream-fix` PR — skip if found (idempotent)
5. Otherwise: branch, `cp` template → `claude.yml`, commit, push, `gh pr create` with a checklist asking the human to verify the fix actually shipped before merging

## Why a template file + cp instead of inline heredoc

GitHub Actions evaluates `${{ ... }}` template syntax inside `run:` blocks before bash runs. The simple `claude.yml` contains `${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`, which would get expanded into a heredoc body — leaking the secret into the file the workflow writes. Storing the template as a static file in `.github/templates/` sidesteps the issue entirely; the workflow just `cp`s it.

## Test plan

- [ ] Merge.
- [ ] Manually trigger via `gh workflow run check-upstream-claude-fix.yml --repo UCD-SERG/shigella` (or the Actions UI).
- [ ] First-run expectation: issue #1281 is still OPEN, so the workflow logs "Issue state=OPEN reason=null — nothing to do." and exits cleanly with no side effects.
- [ ] If/when #1281 closes as COMPLETED, the next Monday run (or a manual dispatch) should open a `simplify/claude-yml-after-upstream-fix` PR for review.