### PR TITLE
Pin use-ai-config on the gha Claude bot callers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,17 @@ jobs:
       # Wires the workflow_dispatch input through so claude.yml can re-dispatch
       # a review on Claude's commits; empty (and ignored) for pull_request runs.
       pr-number: ${{ inputs.pr_number }}
+      # Install the shared Morrison-Lab/ai-config plugin, so the reviewer
+      # applies the lab's shared review conventions rather than only this
+      # repo's own prose. The callee already defaults this to true at @v2, so
+      # it is on today; pinning it in the caller keeps it on if that default
+      # ever moves, and makes the choice visible here rather than implicit in
+      # the callee (#36).
+      use-ai-config: true
     # with:
     #   checkout-submodules: true   # SUBMODULES_TOKEN secret only for private submodules
+    #   plugin-marketplaces: https://github.com/<owner>/<repo>.git  # extra marketplaces on top of ai-config
+    #   plugins: <plugin>@<marketplace-name>  # extra plugins installed alongside ai-config
     #   allowed-bots: 'github-actions[bot],claude'   # accept more bot actors (default: github-actions[bot])
     #   prompt-addendum: |
     #     Repo-specific review guidance (e.g. Quarto/R conventions to enforce).

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,14 @@ jobs:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}               # direct API key; empty when using OAuth
       SUBMODULES_TOKEN: ${{ secrets.SUBMODULES_TOKEN }}   # optional; empty when unset
       WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}       # optional; for editing .github/workflows
+    with:
+      # Install the shared Morrison-Lab/ai-config plugin, so @claude has the
+      # lab's shared skills, slash commands, and workflow conventions rather
+      # than only this repo's own CLAUDE.md. The callee already defaults this
+      # to true at @v2, so it is on today; pinning it in the caller keeps it
+      # on if that default ever moves, and makes the choice visible here
+      # rather than implicit in the callee (#36).
+      use-ai-config: true
     # with:
     #   setup-r: true               # default; set false for non-R repos
     #   install-quarto: true        # for Quarto books
@@ -52,6 +60,8 @@ jobs:
     #   pip-packages: sympy         # pip3 --break-system-packages
     #   checkout-submodules: true   # SUBMODULES_TOKEN secret only for private submodules
     #   link-skills: true           # expose this repo's skills/ as @claude project skills
+    #   plugin-marketplaces: https://github.com/<owner>/<repo>.git  # extra marketplaces on top of ai-config
+    #   plugins: <plugin>@<marketplace-name>  # extra plugins installed alongside ai-config
     #   eager-pr: true              # open the draft PR up front (Copilot-style)
     #   mark-ready-for-review: false # keep Claude's PRs as drafts
     #   reviewer: d-morrison        # re-requested when Claude pushes to a PR

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,14 @@
 * Recorded the roxygen2 version in `Config/roxygen2/version`, which roxygen2
   8.1.0 uses in place of `RoxygenNote` (#32)
 
+* Pinned `use-ai-config: true` explicitly on the Claude and Claude-review
+  `Morrison-Lab/gha@v2` callers (#36).
+  The reusable workflows already default that input to true,
+  so the bot and the reviewer were already installing the shared
+  `ai-config` plugin on every run.
+  Setting it in the caller records that intent
+  and keeps it from changing if the `@v2` default ever moves.
+
 # shigella 0.0.0
 
 Started development.


### PR DESCRIPTION
Closes #36.

## The premise turned out to be already satisfied

#36 asks whether to wire `use-ai-config` into the two `Morrison-Lab/gha`
Claude callers so the reviewer loads the shared corpus directly, on the
understanding that the callers "pass neither, so the reviewer works from
whatever prose the repo happens to carry."

Reading the callee at its pinned tag (the repo's own convention) shows that
premise no longer holds at `@v2`. In **both**
`Morrison-Lab/gha/.github/workflows/claude.yml@v2` and
`claude-code-review.yml@v2`, `use-ai-config` is declared with **`default: true`**,
and the review workflow passes it straight through to `claude-code-action`
(`use-ai-config: ${{ inputs.use-ai-config }}`, ungated, on both the first
and retry review steps). Our two callers omit the input, so it already
resolves to `true`. The canonical `gha` example stubs document this directly:

```
#   use-ai-config: false        # skip the Morrison-Lab/ai-config plugin (installed by default)
```

**So the bot and the reviewer are already installing `ai-config@Morrison-Lab`
on every run.** What was actually stale is this repo's caller stubs: they were
copied from an older template that predates these inputs and never mention
`ai-config`, which is what led to the assumption that it was off.

## What this PR changes

Rather than a no-op "turn it on," this pins the setting explicitly in both
callers and documents it:

- `.github/workflows/claude.yml` — adds an active `with:` block setting
  `use-ai-config: true` (the `@claude` bot).
- `.github/workflows/claude-code-review.yml` — adds `use-ai-config: true`
  alongside the existing `pr-number` input (the reviewer).
- Both — add commented `plugin-marketplaces` / `plugins` lines to the option
  menu, mirroring the canonical `gha` stubs, so the extension path is
  discoverable without being activated.
- `NEWS.md` — an Internal-changes bullet.

**Before:** ai-config on, via an invisible callee default on a floating tag.
**After:** ai-config on, pinned and self-documenting in the caller — identical
runtime behaviour, but the intent survives any future move of the `@v2`
default and the next reader won't repeat the "it's off" assumption. This is
consistent with the repo's `copilot-instructions.md` convention of reading and
pinning against the callee at its tag.

## The three "worth checking" items from #36

- **Does enabling it lengthen review runs / raise permission-denials?** No
  change from this PR: it is already enabled by default, so existing reviews
  (e.g. on #37, #31) already run with the corpus loaded. This PR alters no
  runtime input value, only makes the existing one explicit.
- **Does the corpus conflict with `copilot-instructions.md`?** Any conflict
  would already be in effect on every review today; none has surfaced. A full
  audit of the `ai-config` corpus is out of scope for this caller change.
- **Set `plugins` alongside, or `use-ai-config` alone?** `use-ai-config`
  alone. No additional plugin is needed here, so `plugins` /
  `plugin-marketplaces` are left documented-but-commented pending an
  identified need, keeping this diff to the one decision the issue asked for.

## Verification

- Both workflow files parse as valid YAML; `use-ai-config` is a declared
  `boolean` input on the callee, so `true` is valid.
- `check-new-line-breaks`, `lint-markdown`'s list-item-splice check, and the
  table-split check all run clean against the added `NEWS.md` lines (ran the
  `gha@v2` scripts locally against `origin/main`).
- `DESCRIPTION`'s `Version:` is untouched, per the `version-check` convention.

---
_Generated by [Claude Code](https://claude.ai/code/session_016nNqPzLPjvrs8NxbqyRdxE)_