### PR TITLE
chore(claude): register posit-dev skills marketplace and plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,5 +22,18 @@
       "Bash(gh run list:*)",
       "Bash(typos:*)"
     ]
+  },
+  "extraKnownMarketplaces": {
+    "posit-dev-skills": {
+      "source": {
+        "source": "github",
+        "repo": "posit-dev/skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "r-lib@posit-dev-skills": true,
+    "github@posit-dev-skills": true,
+    "quarto@posit-dev-skills": true
   }
 }


### PR DESCRIPTION
## What

Adds the [`posit-dev/skills`](https://github.com/posit-dev/skills) marketplace to `.claude/settings.json` and enables three of its plugins:

- **`r-lib`** — `testing-r-packages`, `r-package-development`, `cli`, `lifecycle`, `mirai`, `cran-extrachecks`, `r-cli-app`
- **`github`** — `pr-create`, `pr-threads-address`, `pr-threads-resolve`
- **`quarto`** — `quarto-authoring`

## Why

These cover the three things this repo actually does day to day: R package development with devtools/testthat/roxygen2, Quarto authoring for the thesis and manuscript documents, and GitHub PR workflows. Registering them at the project level means every contributor picks up the same skills automatically, instead of each person installing them into their own `~/.claude/skills/`.

Using the marketplace/plugin mechanism rather than vendoring the skill files keeps them tracking upstream — no copies to re-sync when Posit updates them.

## Changes

Only `.claude/settings.json`, additive — the existing `permissions.allow` list is untouched:

```json
"extraKnownMarketplaces": {
  "posit-dev-skills": {
    "source": { "source": "github", "repo": "posit-dev/skills" }
  }
},
"enabledPlugins": {
  "r-lib@posit-dev-skills": true,
  "github@posit-dev-skills": true,
  "quarto@posit-dev-skills": true
}
```

## Notes

- Branched from `main`; contains no work from `thesis-draft`.
- Contributors will be prompted to trust the new marketplace the first time Claude Code loads it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wzu4wh93EzX9T1QcQcKWnz)_